### PR TITLE
Fix expect script bug

### DIFF
--- a/postgres_password.exp
+++ b/postgres_password.exp
@@ -14,10 +14,9 @@ if {$force_conservative} {
 set timeout -1
 spawn sudo su - postgres -c psql
 match_max 100000
-expect -exact "psql (12.2 (Debian 12.2-2.pgdg90+1))\r
-Type \"help\" for help.\r
-\r
-postgres=# "
+expect { 
+ -re "psql.*postgres=# "
+}
 send -- "\\password postgres\r"
 expect -exact "\\password postgres\r
 Enter new password: "


### PR DESCRIPTION
Script tries to match exact psql string returned, but if package version is updated in debian repo that makes the script to hang. We change for a regular expression so it can accept different versions and continues the installation.